### PR TITLE
Using (lazyhash = true) should always make the computed hashCode fiel…

### DIFF
--- a/value-fixture/src/org/immutables/fixture/LazyHashSerializable.java
+++ b/value-fixture/src/org/immutables/fixture/LazyHashSerializable.java
@@ -1,0 +1,11 @@
+package org.immutables.fixture;
+
+import java.io.Serializable;
+import org.immutables.value.Value;
+
+@Value.Immutable(lazyhash = true)
+public interface LazyHashSerializable extends Serializable {
+  String s();
+  boolean b();
+  int i();
+}

--- a/value-fixture/test/org/immutables/fixture/HashTest.java
+++ b/value-fixture/test/org/immutables/fixture/HashTest.java
@@ -16,7 +16,8 @@
 
 package org.immutables.fixture;
 
-import org.immutables.check.Checkers;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
 import static org.immutables.check.Checkers.check;
 
@@ -28,7 +29,7 @@ class HashTest {
   }
 
   @Test
-  void lazyHash() {
+  void lazyHash() throws NoSuchFieldException {
     ImmutableLazyHash h1 = ImmutableLazyHash.builder().s("a").i(1).b(true).build();
     ImmutableLazyHash h2 = ImmutableLazyHash.builder().s("b").i(2).b(false).build();
 
@@ -36,5 +37,28 @@ class HashTest {
     check(h1.hashCode()).not().is(h2.hashCode());
     check(h1.equals(ImmutableLazyHash.builder().s("a").i(1).b(true).build()));
     check(!h1.equals(h2));
+
+    checkHashCodeFieldIsTransient(ImmutableLazyHash.class);
+  }
+
+  @Test
+  void lazyHashSerializable() throws NoSuchFieldException {
+    ImmutableLazyHashSerializable h1 = ImmutableLazyHashSerializable.builder().s("a").i(1).b(true).build();
+    ImmutableLazyHashSerializable h2 = ImmutableLazyHashSerializable.builder().s("b").i(2).b(false).build();
+
+    check(h1.hashCode()).not().is(0); // ensure hashcode is computed
+    check(h1.hashCode()).not().is(h2.hashCode());
+    check(h1.equals(ImmutableLazyHashSerializable.builder().s("a").i(1).b(true).build()));
+    check(!h1.equals(h2));
+
+    checkHashCodeFieldIsTransient(ImmutableLazyHashSerializable.class);
+  }
+
+  @SuppressWarnings("MethodCanBeStatic")
+  private void checkHashCodeFieldIsTransient(Class<?> clazz) throws NoSuchFieldException {
+    // ensure hashCode field is transient
+    Field field = clazz.getDeclaredField("hashCode");
+    field.setAccessible(true);
+    check("hashCode should be transient", Modifier.isTransient(field.getModifiers()));
   }
 }

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2512,7 +2512,7 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
   [eachLine type.syntheticFieldsInjectedAnnotations]
   [jsonIgnore type]
   [if type.useLazyhash][hiddenMutableState type][/if]
-  private[if not type.serial.simple] transient[/if][if type.usePrehashed] final[/if] int hashCode;[if type.useLazyhash] // hashCode lazily computed[/if]
+  private[if ((not type.serial.simple) or type.useLazyhash)] transient[/if][if type.usePrehashed] final[/if] int hashCode;[if type.useLazyhash] // hashCode lazily computed[/if]
 [/if]
 [if type.generateOrdinalValue]
   [jsonIgnore type]


### PR DESCRIPTION
…d transient

When using `(lazyhash = true)` one would expect that the generated `hashCode` field to store the computed hashcode would be `transient`.

This is actually the case for the example above with `LazyHash`:

```
@Value.Immutable(lazyhash = true)
public interface LazyHash {
  String s();
  boolean b();
  int i();
}
```

One can see that `hashCode` is indeed `transient`:

```
public final class ImmutableLazyHash implements LazyHash {
  private final String s;
  private final boolean b;
  private final int i;
  @SuppressWarnings("Immutable")
  private transient int hashCode; // hashCode lazily computed
  ....
  ....

}
```

However, I would have expected the same behavior when making a class/interface `Serializable`:

```
@Value.Immutable(lazyhash = true)
public interface LazyHashSerializable extends Serializable {
  String s();
  boolean b();
  int i();
}
```

But the generated class actually shows that `hashCode` is not `transient`:

```
public final class ImmutableLazyHashSerializable implements LazyHashSerializable {
  private final String s;
  private final boolean b;
  private final int i;
  @SuppressWarnings("Immutable")
  private int hashCode; // hashCode lazily computed
  ....
  ....
}
```